### PR TITLE
Removed Default VPC CIDR block value when using existing VPC 

### DIFF
--- a/templates/quickstart-cisco-ise-on-aws-workload.template.yaml
+++ b/templates/quickstart-cisco-ise-on-aws-workload.template.yaml
@@ -676,7 +676,6 @@ Parameters:
   VPCCIDR:
     AllowedPattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(1[6-9]|2[0-8]))$'
     ConstraintDescription: CIDR block parameter must be in the form "x.x.x.x/16-28".
-    Default: 10.0.0.0/16
     Description: CIDR block for the VPC.
     Type: String
   LBPrivateAddressSubnet1:


### PR DESCRIPTION
Removed the Default "10.0.0.0/16" VPC CIDR string as this value must be user-defined when selecting existing VPC from parameter `VPCID with Type: AWS::EC2::VPC::Id` 

The default "10.0.0.0/16" can be the first deployment for a user who may have a different VPC CIDR for the VPC selected in the Parameter.